### PR TITLE
Refactor arrays

### DIFF
--- a/src/Fighter/Net/Route.php
+++ b/src/Fighter/Net/Route.php
@@ -7,7 +7,7 @@ class Route {
     public Map<mixed, mixed> $params = Map{};
     public string $splat = '';
     public string $regex = '';
-    private array<mixed, mixed> $ids = [];
+    private Map<string, mixed> $ids = Map {};
 
     public function __construct(
         private string $pattern, public mixed $callback,
@@ -27,7 +27,7 @@ class Route {
             return true;
         }
 
-        $this->ids = array();
+        $this->ids = Map {};
         $last_char = substr($this->pattern, -1);
         if ($last_char === '*') {
             $n = 0;

--- a/src/Fighter/Net/Route.php
+++ b/src/Fighter/Net/Route.php
@@ -15,7 +15,8 @@ class Route {
     {}
 
     public function matchMethod(string $method): bool {
-        return count(array_intersect(array($method, '*'), $this->methods)) > 0;
+        return $this->methods->linearSearch('*') > -1 ||
+                $this->methods->linearSearch($method) > -1;
     }
 
     public function matchUrl(string $url): bool {

--- a/src/Fighter/Net/Route.php
+++ b/src/Fighter/Net/Route.php
@@ -42,7 +42,7 @@ class Route {
             $this->splat = (string)substr($url, $i+1);
         }
 
-        $regex = str_replace(array(')','/*'), array(')?','(/?|/.*?)'), $this->pattern);
+        $regex = str_replace([')','/*'], [')?','(/?|/.*?)'], $this->pattern);
 
         $regex = preg_replace_callback(
             '#@([\w]+)(:([^/\(\)]*))?#',

--- a/src/Fighter/Net/Router.php
+++ b/src/Fighter/Net/Router.php
@@ -8,16 +8,17 @@ class Router {
     private int $index = 0;
 
     public function map(string $pattern, mixed $callback, bool $pass_route = false): void {
+        $pattern = trim($pattern);
         $url = $pattern;
         $methods = Vector{'*'};
 
         if (strpos($pattern, ' ') !== false) {
-            list($method, $url) = explode(' ', trim($pattern), 2);
+            list($method, $url) = explode(' ', $pattern, 2);
 
             $methods = new Vector(explode('|', $method));
         }
 
-        $this->routes[] = new Route($url, $callback, $methods, $pass_route);
+        $this->routes[] = new Route(trim($url), $callback, $methods, $pass_route);
     }
 
     public function route(Request $request): ?Route {

--- a/src/Fighter/Test/Client.php
+++ b/src/Fighter/Test/Client.php
@@ -23,12 +23,12 @@ class Client {
         return $this->app->getResponse();
     }
 
-    private function getRequestAndMethod(string $route): array<string> {
+    private function getRequestAndMethod(string $route): Vector<string> {
         $match = [];
         if (preg_match("/(GET|POST|PUT|DELETE|OPTIONS|HEAD) (.+)/", $route, $match)) {
-            return [$match[1], $match[2]];
+            return Vector {$match[1], $match[2]};
         }
-        return ['GET', $route];
+        return Vector {'GET', $route};
     }
 
     public function routeExists(string $route): bool {

--- a/src/Fighter/Test/WebCase.php
+++ b/src/Fighter/Test/WebCase.php
@@ -4,7 +4,7 @@ namespace Fighter\Test;
 
 class WebCase extends \PHPUnit_Framework_TestCase {
 
-    public function __construct(?string $name = null, array $data = array(), string $dataName = '') {
+    public function __construct(?string $name = null, array $data = [], string $dataName = '') {
         parent::__construct($name, $data, $dataName);
         putenv('FIGHTER_MUTE=1');
     }

--- a/src/Fighter/Util/Binder.php
+++ b/src/Fighter/Util/Binder.php
@@ -5,11 +5,15 @@ namespace Fighter\Util;
 trait Binder {
     protected Map<string, mixed> $core_binds = Map {};
 
-    public function bind(string $name, mixed $bind): void {
+    /**
+     * @throws \InvalidArgumentException on not callable bind
+     */
+    public function bind(string $name, mixed $bind): this {
         if (!is_callable($bind)) {
             throw new \InvalidArgumentException("$name is not callable");
         }
         $this->core_binds[$name] = $bind;
+        return $this;
     }
 
     public function __call(string $name, array<mixed> $params): mixed {

--- a/t/Fighter/Net/RouterTest.php
+++ b/t/Fighter/Net/RouterTest.php
@@ -28,6 +28,18 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($response, $str);
     }
 
+    public function testRemoveRouteURLWhitespaces(): void {
+        $this->router->map(' /path ', array($this, 'ok'));
+        $this->request->url = '/path';
+        $this->check('OK');
+    }
+
+    public function testRemoveRouteWhitespaces(): void {
+        $this->router->map(' POST|GET /path ', array($this, 'ok'));
+        $this->request->url = '/path';
+        $this->check('OK');
+    }
+
     // Simple path
     public function testPathRoute(): void {
         $this->router->map('/path', array($this, 'ok'));

--- a/t/Fighter/Util/BinderTest.php
+++ b/t/Fighter/Util/BinderTest.php
@@ -19,6 +19,15 @@ class BinderTest extends PHPUnit_Framework_TestCase {
         $this->obj = new Test_Fighter_Util_BinderObject();
     }
 
+    public function testBindReturnObjectSelfReference() {
+        $this->assertSame(
+            $this->obj,
+            $this->obj->bind('bind1', () ==> {
+                return 'foo';
+            })
+        );
+    }
+
     public function testClosureBinding() {
         $this->obj->bind('bind1', () ==> {
             return 'foo';


### PR DESCRIPTION
Trying to use `Map/Vector` where possible, or use `[]` syntax instead of `array()`.

Extra:
- cleanup white spaces from routes before handling them
- binder::bind returns object self reference (fluent interface)
