### PR TITLE
Renamed Http to HttpTrait

### DIFF
--- a/src/Fighter/Net/HttpTrait.php
+++ b/src/Fighter/Net/HttpTrait.php
@@ -2,7 +2,7 @@
 
 namespace Fighter\Net;
 
-trait Http {
+trait HttpTrait {
     public function getServerParams(): Map<string, string> {
         return Map::fromArray($_SERVER);
     }

--- a/src/Fighter/Net/Request.php
+++ b/src/Fighter/Net/Request.php
@@ -23,7 +23,7 @@ type RequestArg = shape(
 );
 
 class Request {
-    use Http;
+    use HttpTrait;
 
     public Map<string, mixed> $request = Map{};
 

--- a/src/Fighter/Net/Response.php
+++ b/src/Fighter/Net/Response.php
@@ -3,7 +3,7 @@
 namespace Fighter\Net;
 
 class Response {
-    use Http;
+    use HttpTrait;
 
     public string $type = '';
     protected int $status = 200;


### PR DESCRIPTION
It is a recommendation on PSR to name traits ending with Trait.
